### PR TITLE
Amended 2019 Version match fallback.

### DIFF
--- a/Reveche/MainWindow.xaml.cs
+++ b/Reveche/MainWindow.xaml.cs
@@ -22,6 +22,8 @@ namespace Reveche
     private const string StreamName = "BasicFileInfo";
 
     private static Regex FoundYear = new Regex(@"\s\d{4}\s");
+    private static Regex FoundYear2019 = new Regex(@"^(\d{4})\u0012");
+
     private ObservableCollection<RevitFile> SourceCollection = new ObservableCollection<RevitFile>();
     List<String> RevitFiles = new List<string>();
 
@@ -130,14 +132,15 @@ namespace Reveche
         //2019+ don't use the conventions above :(
         if (string.IsNullOrEmpty(rf.Version))
         {
-          try
+          foreach (var info in fileInfoData.Select((val, i) => new { i, val }))
           {
-            rf.Version = fileInfoData[4].Replace("\u0012", "");
-            rf.AdditionalInfo = "Build: " + fileInfoData[5];
-          }
-          catch 
-          {
-            //nope
+            Match yearMatch = FoundYear2019.Match(info.val);
+          
+            if (yearMatch.Success) 
+            {
+              rf.Version = yearMatch.Groups[1].Value;
+              rf.AdditionalInfo = "Build: " + fileInfoData[info.i+1];
+            }
           }
         }
       }

--- a/Reveche/MainWindow.xaml.cs
+++ b/Reveche/MainWindow.xaml.cs
@@ -132,8 +132,8 @@ namespace Reveche
         {
           try
           {
-            rf.Version = fileInfoData[2].Replace("\u0012", "");
-            rf.AdditionalInfo = fileInfoData[3];
+            rf.Version = fileInfoData[4].Replace("\u0012", "");
+            rf.AdditionalInfo = "Build: " + fileInfoData[5];
           }
           catch 
           {


### PR DESCRIPTION
fixes #3 

I haven't come across any 2019 files that use the [2] and [3] from the previous build, but only [4] an [5].

Assuming the [2] & [3] was valid, then the address mapping may need to be pattern based as per the 'Autodesk' search for pre-2019.

As such, this change searches for the version in the format pattern I have observed. For now, I have also assumed that the build information always follows the version address at the next index.

