### PR TITLE
Added multiple file addition from list txt file

### DIFF
--- a/Reveche/MainWindow.xaml
+++ b/Reveche/MainWindow.xaml
@@ -40,13 +40,20 @@
         <Canvas Grid.ColumnSpan="3" Name="whitespace" Grid.RowSpan="3" Background="WhiteSmoke" Opacity=".70" Panel.ZIndex="100" Visibility="Hidden" Grid.Row="1" />
 
 
-        <Label Grid.Row="0" Content="Drag and drop multiple Files and Flders, or use the 'Add Files' button." Margin="5"/>
+        <Label Grid.Row="0" Content="Drag and drop multiple Files and Folders, explore files to add with the 'Add Files' button or add files from a file list." Margin="5"/>
         <DockPanel Margin="5" Grid.Row="1">
             <Button ToolTip="Add Files" HorizontalAlignment="Left" Name="AddFilesBtn" Click="AddFilesBtn_OnClick"  >
                 <StackPanel Orientation="Horizontal">
                     <Path   Margin="5,0,0,0" Height="15" Width="15" Stretch="Uniform" Fill="Green"  Data="M50,100C22.4,100,0,77.6,0,50S22.4,0,50,0s50,22.4,50,50S77.6,100,50,100z M24.4,55.7h19.2V75H56V55.7h19.2
 	V43.5H56V24.2H43.6v19.2H24.4V55.7z" UseLayoutRounding="False"/>
                     <TextBlock Margin="5,2" Text="Add Files" />
+                </StackPanel>
+            </Button>
+            <Button ToolTip="Add Files from List"   Margin="5,0,0,0" HorizontalAlignment="Left" Name="AddFilesFromListBtn" Click="AddFilesFromListBtn_OnClick"  >
+                <StackPanel Orientation="Horizontal">
+                    <Path   Margin="5,0,0,0" Height="15" Width="15" Stretch="Uniform" Fill="Green"  Data="M50,100C22.4,100,0,77.6,0,50S22.4,0,50,0s50,22.4,50,50S77.6,100,50,100z M24.4,55.7h19.2V75H56V55.7h19.2
+	V43.5H56V24.2H43.6v19.2H24.4V55.7z" UseLayoutRounding="False"/>
+                    <TextBlock Margin="5,2" Text="Add Files From List" />
                 </StackPanel>
             </Button>
             <Button ToolTip="Remove selected files"  Margin="5,0,0,0"  Name="RemoveFilesBtn" Click="RemoveFilesBtn_OnClick" Style="{StaticResource ButtonListEnablerStyle}">

--- a/Reveche/MainWindow.xaml.cs
+++ b/Reveche/MainWindow.xaml.cs
@@ -26,9 +26,7 @@ namespace Reveche
 
     private ObservableCollection<RevitFile> SourceCollection = new ObservableCollection<RevitFile>();
     List<String> RevitFiles = new List<string>();
-
     
-
     public MainWindow()
     {
       InitializeComponent();
@@ -64,7 +62,6 @@ namespace Reveche
             RevitFiles.Add(s);
           }
             
-
         }
         //MessageBox.Show("Completed in " + (DateTime.Now - start).TotalSeconds.ToString() + " seconds.");
         //user double clicked on the exe
@@ -96,7 +93,6 @@ namespace Reveche
         MessageBox.Show(ex.Message);
       }
     }
-
 
     private static void GetYearFromFileInfo(string pathToRevitFile, RevitFile rf)
     {
@@ -149,7 +145,6 @@ namespace Reveche
         MessageBox.Show(ex.Message);
       }
     }
-
    
     /// <summary>
     /// Dumb way to get current RenameType
@@ -210,6 +205,48 @@ namespace Reveche
       catch (System.Exception ex1)
       {
         MessageBox.Show("exception: " + ex1);
+      }
+
+    }
+    /// <summary>
+    /// Click Add Files from List
+    /// </summary>
+    /// <param name="sender"></param>
+    /// <param name="e"></param>
+    private void AddFilesFromListBtn_OnClick( object sender, RoutedEventArgs e ) {
+      try {
+        var openFileDialog1 = new Microsoft.Win32.OpenFileDialog();
+        openFileDialog1.Title = "Select file list";
+        openFileDialog1.Filter = "Text Files (*.txt)|*.txt|All files (*.*)|*.*";
+        openFileDialog1.Multiselect = false;
+
+        openFileDialog1.RestoreDirectory = true;
+        var result = openFileDialog1.ShowDialog(); // Show the dialog.
+
+        if ( result == true ) // Test result.
+        {
+          // Parse file to extract valid filenames into a array equivalent to the open file dialog.
+
+          var fileList = new List<string>();
+
+          if ( File.Exists( openFileDialog1.FileName ) ) {
+
+            System.IO.StreamReader file = new System.IO.StreamReader( openFileDialog1.FileName );
+            string line;
+            while ( ( line = file.ReadLine() ) != null ) {
+            
+              if ( File.Exists( line ) ) {
+                fileList.Add( line );
+              }
+            }
+
+            ProcessSourceFiles( fileList.ToArray() );
+          }
+
+        }
+      }
+      catch ( System.Exception ex1 ) {
+        MessageBox.Show( "exception: " + ex1 );
       }
 
     }
@@ -277,8 +314,6 @@ namespace Reveche
       }
     }
 
-
-
     private void Window_DragEnter(object sender, DragEventArgs e)
     {
       whitespace.Visibility = System.Windows.Visibility.Visible;
@@ -308,13 +343,8 @@ namespace Reveche
       }
     }
     #endregion
-
    
-
-
-
     #region version stuff
-
 
     // Code thanks to Jeremy Tammik
     // Please check his blog
@@ -344,7 +374,6 @@ namespace Reveche
                 "File doesn't contain {0} stream", StreamName));
           }
 
-
           StreamInfo imageStreamInfo =
               ssRoot.BaseRoot.GetStreamInfo(StreamName);
 
@@ -363,7 +392,6 @@ namespace Reveche
       }
       return null;
     }
-
 
 
     public static class StructuredStorageUtils


### PR DESCRIPTION
This pull request adds the ability to process a text file of file paths and have them be checked in that way. File lists may be produced as part of other workflows and point to many locations on a machine/server. Adding them bit by bit is time-consuming.

Assumes for now that a text file is a file path per line. There is little checking involved other than the file exists at the path. This relies on the Revit validity chick already being performed in the process list function.